### PR TITLE
chore: more strict husky pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run pretty-quick
+npm run pretty-quick && make build lint release-file

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ lint:
 	@npm run lint
 
 ${RELEASE_FILE}: dist/index.js ${RELEASE_STATIC_CONTENT} 
-	@tar -cf release.tar dist ${RELEASE_STATIC_CONTENT} && gzip release.tar
+	@tar -cf release.tar dist ${RELEASE_STATIC_CONTENT} && rm -f release.tar.gz && gzip release.tar
 
 temp/temp-created:
 	@mkdir -p temp && touch temp/temp-created


### PR DESCRIPTION
* do build, lint, release file upon commit
* don't fail on make release-file if there is already a gz file